### PR TITLE
[Merged by Bors] - Rename `IntoVNode` trait `into` member to `into_vnode`.

### DIFF
--- a/utils/malvolio/src/into_vnode.rs
+++ b/utils/malvolio/src/into_vnode.rs
@@ -1,4 +1,4 @@
 #[cfg(feature = "with_yew")]
 pub trait IntoVNode {
-    fn into(self) -> ::yew::virtual_dom::VNode;
+    fn into_vnode(self) -> ::yew::virtual_dom::VNode;
 }

--- a/utils/malvolio/src/macros.rs
+++ b/utils/malvolio/src/macros.rs
@@ -58,7 +58,7 @@ macro_rules! impl_of_heading_new_fn {
 macro_rules! heading_of_vnode {
     ($name:ident) => {
         impl $crate::into_vnode::IntoVNode for $name {
-            fn into(self) -> ::yew::virtual_dom::VNode {
+            fn into_vnode(self) -> ::yew::virtual_dom::VNode {
                 let mut vtag = ::yew::virtual_dom::VTag::new(stringify!($name));
                 for (k, v) in self.1.into_iter() {
                     vtag.add_attribute(k, &v);
@@ -113,10 +113,10 @@ macro_rules! into_grouping_union_without_lifetimes {
 macro_rules! into_vnode_for_grouping_enum {
     ($name:ident, $($variant:ident),*) => {
         impl $crate::into_vnode::IntoVNode for $name {
-            fn into(self) -> yew::virtual_dom::VNode {
+            fn into_vnode(self) -> yew::virtual_dom::VNode {
                 match self {
                     $(
-                        Self::$variant(x) => {$crate::into_vnode::IntoVNode::into(x)}
+                        Self::$variant(x) => {$crate::into_vnode::IntoVNode::into_vnode(x)}
                     ),*
 
                 }
@@ -141,7 +141,7 @@ macro_rules! to_html {
     () => {
         #[cfg(feature = "with_yew")]
         pub fn to_html(self) -> yew::virtual_dom::VNode {
-            $crate::into_vnode::IntoVNode::into(self)
+            $crate::into_vnode::IntoVNode::into_vnode(self)
         }
     };
 }

--- a/utils/malvolio/src/tags/a.rs
+++ b/utils/malvolio/src/tags/a.rs
@@ -34,7 +34,7 @@ pub struct A {
 
 #[cfg(feature = "with_yew")]
 impl IntoVNode for A {
-    fn into(self) -> yew::virtual_dom::VNode {
+    fn into_vnode(self) -> yew::virtual_dom::VNode {
         let mut vnode = yew::virtual_dom::VTag::new("a");
         for (a, b) in self.attrs {
             vnode.add_attribute(a, &b.to_string())

--- a/utils/malvolio/src/tags/body/mod.rs
+++ b/utils/malvolio/src/tags/body/mod.rs
@@ -13,9 +13,9 @@ pub struct Body {
 
 #[cfg(feature = "with_yew")]
 impl IntoVNode for Body {
-    fn into(self) -> yew::virtual_dom::VNode {
+    fn into_vnode(self) -> yew::virtual_dom::VNode {
         let mut vtag = yew::virtual_dom::VTag::new("body");
-        vtag.add_children(self.children.into_iter().map(IntoVNode::into));
+        vtag.add_children(self.children.into_iter().map(IntoVNode::into_vnode));
         vtag.into()
     }
 }

--- a/utils/malvolio/src/tags/br.rs
+++ b/utils/malvolio/src/tags/br.rs
@@ -29,7 +29,7 @@ impl Display for Br {
 
 #[cfg(feature = "with_yew")]
 impl IntoVNode for Br {
-    fn into(self) -> yew::virtual_dom::VNode {
+    fn into_vnode(self) -> yew::virtual_dom::VNode {
         yew::virtual_dom::VTag::new("br").into()
     }
 }

--- a/utils/malvolio/src/tags/div.rs
+++ b/utils/malvolio/src/tags/div.rs
@@ -27,9 +27,9 @@ pub struct Div {
 
 #[cfg(feature = "with_yew")]
 impl IntoVNode for Div {
-    fn into(self) -> yew::virtual_dom::VNode {
+    fn into_vnode(self) -> yew::virtual_dom::VNode {
         let mut vtag = yew::virtual_dom::VTag::new("div");
-        vtag.add_children(self.children.into_iter().map(IntoVNode::into));
+        vtag.add_children(self.children.into_iter().map(IntoVNode::into_vnode));
         for (a, b) in self.attrs {
             vtag.add_attribute(a, &b.to_string())
         }

--- a/utils/malvolio/src/tags/form/mod.rs
+++ b/utils/malvolio/src/tags/form/mod.rs
@@ -60,9 +60,9 @@ pub struct Form {
 
 #[cfg(feature = "with_yew")]
 impl IntoVNode for Form {
-    fn into(self) -> yew::virtual_dom::VNode {
+    fn into_vnode(self) -> yew::virtual_dom::VNode {
         let mut vtag = yew::virtual_dom::VTag::new("form");
-        vtag.add_children(self.children.into_iter().map(IntoVNode::into));
+        vtag.add_children(self.children.into_iter().map(IntoVNode::into_vnode));
         for (a, b) in self.attrs {
             vtag.add_attribute(a, &b.to_string())
         }

--- a/utils/malvolio/src/tags/head/mod.rs
+++ b/utils/malvolio/src/tags/head/mod.rs
@@ -13,9 +13,9 @@ pub struct Head {
 
 #[cfg(feature = "with_yew")]
 impl IntoVNode for Head {
-    fn into(self) -> yew::virtual_dom::VNode {
+    fn into_vnode(self) -> yew::virtual_dom::VNode {
         let mut tag = yew::virtual_dom::VTag::new("head");
-        tag.add_children(self.children.into_iter().map(IntoVNode::into));
+        tag.add_children(self.children.into_iter().map(IntoVNode::into_vnode));
         tag.into()
     }
 }

--- a/utils/malvolio/src/tags/html.rs
+++ b/utils/malvolio/src/tags/html.rs
@@ -28,9 +28,9 @@ pub struct Html {
 
 #[cfg(feature = "with_yew")]
 impl IntoVNode for Html {
-    fn into(self) -> yew::virtual_dom::VNode {
+    fn into_vnode(self) -> yew::virtual_dom::VNode {
         let mut tag = yew::virtual_dom::VTag::new("html");
-        tag.add_children(vec![IntoVNode::into(self.head), IntoVNode::into(self.body)]);
+        tag.add_children(vec![IntoVNode::into_vnode(self.head), IntoVNode::into_vnode(self.body)]);
         tag.into()
     }
 }

--- a/utils/malvolio/src/tags/html.rs
+++ b/utils/malvolio/src/tags/html.rs
@@ -30,7 +30,10 @@ pub struct Html {
 impl IntoVNode for Html {
     fn into_vnode(self) -> yew::virtual_dom::VNode {
         let mut tag = yew::virtual_dom::VTag::new("html");
-        tag.add_children(vec![IntoVNode::into_vnode(self.head), IntoVNode::into_vnode(self.body)]);
+        tag.add_children(vec![
+            IntoVNode::into_vnode(self.head),
+            IntoVNode::into_vnode(self.body),
+        ]);
         tag.into()
     }
 }

--- a/utils/malvolio/src/tags/input.rs
+++ b/utils/malvolio/src/tags/input.rs
@@ -28,7 +28,7 @@ pub struct Input {
 
 #[cfg(feature = "with_yew")]
 impl IntoVNode for Input {
-    fn into(self) -> yew::virtual_dom::VNode {
+    fn into_vnode(self) -> yew::virtual_dom::VNode {
         let mut vtag = yew::virtual_dom::VTag::new("input");
         self.attrs
             .clone()

--- a/utils/malvolio/src/tags/meta.rs
+++ b/utils/malvolio/src/tags/meta.rs
@@ -33,7 +33,7 @@ impl Meta {
 
 #[cfg(feature = "with_yew")]
 impl IntoVNode for Meta {
-    fn into(self) -> yew::virtual_dom::VNode {
+    fn into_vnode(self) -> yew::virtual_dom::VNode {
         let mut vtag = yew::virtual_dom::VTag::new("meta");
         for (a, b) in self.attrs {
             vtag.add_attribute(a, &b.to_string())

--- a/utils/malvolio/src/tags/option.rs
+++ b/utils/malvolio/src/tags/option.rs
@@ -75,7 +75,7 @@ impl Display for SelectOption {
 
 #[cfg(feature = "with_yew")]
 impl IntoVNode for SelectOption {
-    fn into(self) -> yew::virtual_dom::VNode {
+    fn into_vnode(self) -> yew::virtual_dom::VNode {
         let mut vtag = yew::virtual_dom::VTag::new("option");
         write_attributes_to_vtag(&self.attrs, &mut vtag);
         vtag.add_child(::yew::virtual_dom::VText::new(self.text.to_string()).into());

--- a/utils/malvolio/src/tags/p.rs
+++ b/utils/malvolio/src/tags/p.rs
@@ -17,9 +17,9 @@ pub struct P {
 
 #[cfg(feature = "with_yew")]
 impl IntoVNode for P {
-    fn into(self) -> yew::virtual_dom::VNode {
+    fn into_vnode(self) -> yew::virtual_dom::VNode {
         let mut vtag = yew::virtual_dom::VTag::new("br");
-        vtag.add_children(self.children.into_iter().map(IntoVNode::into));
+        vtag.add_children(self.children.into_iter().map(IntoVNode::into_vnode));
         vtag.into()
     }
 }

--- a/utils/malvolio/src/tags/select.rs
+++ b/utils/malvolio/src/tags/select.rs
@@ -74,10 +74,10 @@ impl Display for Select {
 
 #[cfg(feature = "with_yew")]
 impl IntoVNode for Select {
-    fn into(self) -> yew::virtual_dom::VNode {
+    fn into_vnode(self) -> yew::virtual_dom::VNode {
         let mut vtag = yew::virtual_dom::VTag::new("select");
         write_attributes_to_vtag(&self.attrs, &mut vtag);
-        vtag.add_children(self.children.into_iter().map(IntoVNode::into));
+        vtag.add_children(self.children.into_iter().map(IntoVNode::into_vnode));
         vtag.into()
     }
 }


### PR DESCRIPTION
This is to disambiguate it from the `Into` trait.