### PR TITLE
[Merged by Bors] - Delete grcov.yml

### DIFF
--- a/grcov.yml
+++ b/grcov.yml
@@ -1,1 +1,0 @@
-output-path: "./coverage.txt"


### PR DESCRIPTION
We stopped using grcov because html5ever refused to build when using it and instead replaced it with `cargo-tarpaulin`.